### PR TITLE
未完

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,43 @@ nftables 的分流特性上，对于同一 Tracker 始终篡改为 TCP 或 UDP�
 
 ## 快速使用
 
-## 容器网络
+**host 网络 + 传统模式**
+
+```
+docker run -d \
+--name BitComet \
+--net host \
+-v /BC目录:/BitComet \
+-v /DL目录:/Downloads \
+-v /PBH目录:/PeerBanHelper \
+-e BITCOMET_WEBUI_USERNAME='BC WebUI 用户名' \
+-e BITCOMET_WEBUI_PASSWORD='BC WebUI 密码' \
+-e BITCOMET_WEBUI_PORT='BC WebUI 端口' \
+-e BITCOMET_BT_PORT=‘BC BT 端口’ \
+-e PBH_WEBUI_TOKEN='PBH Token' \
+-e PBH_WEBUI_PORT='PBH WebUI 端口' \
+bitcometpostbar/bitcomet:latest
+```
+
+**bridge 网络 + 改包模式**
+
+```
+docker run -d \
+--name BitComet \
+--cap-add \
+-v /BC目录:/BitComet \
+-v /DL目录:/Downloads \
+-v /PBH目录:/PeerBanHelper \
+-e BITCOMET_WEBUI_USERNAME='BC WebUI 用户名' \
+-e BITCOMET_WEBUI_PASSWORD='BC WebUI 密码' \
+-e BITCOMET_WEBUI_PORT='BC WebUI 端口' \
+-e BITCOMET_BT_PORT=‘BC BT 端口’ \
+-e PBH_WEBUI_TOKEN='PBH Token' \
+-e PBH_WEBUI_PORT='PBH WebUI 端口' \
+bitcometpostbar/bitcomet:latest
+```
+
+## 网络配置
 
 本镜像为提升易用性，尽可能地考虑了用户的网络环境，但仍有需要注意的地方。
 
@@ -92,6 +128,8 @@ bridge 网络下如要使用 IPv6，还需要额外的配置。
 host 网络 + 传统模式 由于会改变下载器的监听端口，防火墙的 IPv6 规则可能需要更改。
 
 macvlan 网络是最理想的，但同样需要额外的配置。
+
+## 目录配置
 
 ## 变量说明
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,96 @@
 
 Docker Edition of BitComet Web UI by Post-Bar (unofficial mod)
 
-优化初始配置，并集成 PeerBanHelper 与 STUN 穿透。
+优化初始配置，并集成 STUN 穿透 与 PeerBanHelper，STUN 穿透需要锥形 NAT 环境。
 
-STUN 穿透需要锥形 NAT 环境及 网关开启 UPnP 功能。
+　*欢迎移植其他下载器*
+
+
+## 穿透模式
+
+本镜像提供两种穿透模式，分别称之为 **传统模式** 和 **改包模式**。
+
+BitTorrent 协议的特性上，需要向 Tracker 通告 NAPT 公网端口，其他 Peer 用户才能获取正确的信息并发起连接。
+
+而在 **运营商级 NAT** 下，内网端口与公网端口不一致且不固定，因此需要动态修改 BT 下载器向 Tracker 通告的端口。
+
+**传统模式** 的原理是获取 NAPT 公网端口后，修改为下载器的监听端口，以达到让下载器向 Tracker 通告公网端口的效果。
+
+**改包模式** 的原理是获取 NAPT 公网端口后，通过防火墙框架 nftables 识别下载器的 Tracker 流量，并把通告端口篡改为公网端口。目前支持 HTTP(S) 与 UDP Tracker，WS(S) Tracker 尚未涉及。
+
+---
+
+**传统模式** 的穿透通道仅支持 TCP 或 UDP 二选一。因为 TCP 与 UDP 的公网端口也不一致，而通常下载器无法分别监听不同的端口号。
+
+**改包模式** 的穿透通道可单独 TCP 或 UDP，也可两者同时启用。TCP + UDP 模式下，nftables 会基于 Tracker 服务器的 IP 地址进行 50:50 负载均衡。
+
+nftables 的分流特性上，对于同一 Tracker 始终篡改为 TCP 或 UDP，以免服务器频繁变更端口。但**对于 HTTPS Tracker，由于使用了中间人攻击实现解密**，nftables 检测到的服务器地址始终为 `127.0.0.1`，因此对所有 HTTPS Tracker 都会通告同一个端口号。
+
+　*尚未确认具体会通告 TCP 还是 UDP*
+
+---
+
+对于 HTTP(S) 改包，nftables 规则仅匹配路径为 `/announce` 的 HTTP 请求
+
+以下这样的 Tracker URL 能被识别
+
+`http://example.com/announce`
+
+以下这样的 Tracker URL 会被忽略
+
+`http://example.com/usertoken/announce`
+
+以下这样的 Tracker URL 仍可匹配
+
+`http://example.com/announce.php`
+
+但目前以数据包的二进制偏移量为基准识别并篡改端口，若字符太多将会超出走查范围。（考虑到执行效率，并不会走查整个数据包）
+
+## NAT 类型
+
+本镜像会在启动时 **进行 NAT 映射行为检测，不进行过滤行为检测**，假定用户为 **受限制锥形 NAT**。
+
+可通过容器自动配置 UPnP，或用户自行配置端口映射。其中 **传统模式** 依赖 UPnP，而 **改包模式** 则不限。
+
+### 端口映射
+
+**传统模式** 下，由于 **穿透通道的本地端口与下载器的监听端口不一致且无法固定**，因此需要通过 UPnP 向网关请求一条 **内外不一致** 的端口映射规则。
+
+**改包模式** 巧妙地利用 NAT 优先级的特性，**穿透通道的本地端口与下载器的监听端口一致且始终不变**，因此用户侧网关无需再进行端口映射。但由于防火墙的过滤，仍需要配置 **内外一致** 的端口映射规则以达到防火墙放行的效果。
 
 # 使用说明
 
-## 网络配置
+## 快速使用
 
-**强烈建议使用 Host 网络**，如有需求也可自行配置 macvlan 网络
+## 容器网络
 
-使用 Bridge 网络时，需要自行解决 UPnP 跨网段请求以及 IPv6 等问题
+本镜像为提升易用性，尽可能地考虑了用户的网络环境，但仍有需要注意的地方。
+
+### bridge 网络
+
+* **传统模式**：bridge 网络下，容器的 UPnP 的可达性通常受到阻碍。本镜像仍会尝试请求 UPnP 规则，但可能需要用户自行解决可达性问题。
+
+* **改包模式**：bridge 网络下的推荐模式。仅需在容器启动时指定 `-p` 参数映射端口。但 **操作 nftables 需要 `NET_ADMIN` 权限**，当然也可以直接开启 **特权模式 `privileged`**。
+
+### host 网络
+
+* **传统模式**：host 网络下的推荐模式。只要网关开启了 UPnP 功能，可以说是开箱即用。
+
+* **改包模式**：同样需要 `NET_ADMIN` 权限或特权模式。host 网络下，宿主的所有通信（包括其他容器）都会遍历 nftables 规则，尽管规则已尽可能地精确匹配 Tracker 流量。
+
+#### HTTPS 改包的额外说明
+
+**解密 HTTPS Tracker 流量时，中间人攻击需要信任证书**。该操作只能在当前容器内生效，因此在同一 host 网络下配置多个同方案的穿透时，**HTTPS Tracker 改包仅对最后一个添加规则的容器生效**。
+
+为避免拦截不必要的 HTTPS 流量而导致网络性能损耗或影响其他程序的通信，仅匹配 [HTTPS Tracker 列表](https://oniicyan.pages.dev/https_trackers.txt) 中的地址与端口。如需要添加自定义 HTTPS Tracker，请编辑 `/BitComet/CustomHttpsTrackers.txt`。
+
+---
+
+bridge 网络下如要使用 IPv6，还需要额外的配置。
+
+host 网络 + 传统模式 由于会改变下载器的监听端口，防火墙的 IPv6 规则可能需要更改。
+
+macvlan 网络是最理想的，但同样需要额外的配置。
 
 ## 变量说明
 

--- a/files/nftables.sh
+++ b/files/nftables.sh
@@ -21,7 +21,8 @@ pkill -Af $0.*$L4PROTO
 LOG $L4PROTO nftables 规则已存在，无需更新 && exit
 
 # 防止脚本同时操作 nftables 导致冲突
-[ $L4PROTO = udp ] && [ -f StunNftables_tcp ] && until [ $(($(date +%s)-$(stat -c %Y StunNftables_tcp))) -gt 10 ]; do sleep 1; done
+# [ $L4PROTO = udp ] && [ -f StunNftables_tcp ] && until [ $(($(date +%s)-$(stat -c %Y StunNftables_tcp))) -gt 10 ]; do sleep 1; done
+[ $L4PROTO = udp ] && while pgrep -f $0.+tcp >/dev/null; do sleep 1; done
 
 # 初始化 nftables
 nft add table ip STUN

--- a/files/nftables.sh
+++ b/files/nftables.sh
@@ -138,8 +138,8 @@ UPDATE_HTTPS() {
 	[ -f StunHttpsTrackers ] || UPDATE_HTTPS
 	[ $(($(date +%s)-$(stat -c %Y StunHttpsTrackers))) -gt 3600 ] && UPDATE_HTTPS
 	nft add chain ip STUN NAT_OUTPUT { type nat hook output priority dstnat \; }
-	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
-	nft insert rule ip STUN NAT_OUTPUT $OIFNAME $APPRULE skuid != 58443 ip daddr . tcp dport @BTTR_HTTPS counter redirect to $StunMitmEnPort comment $NFTNAME
+	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"${NFTNAME}_mitm\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
+	nft insert rule ip STUN NAT_OUTPUT $OIFNAME $APPRULE skuid != 58443 ip daddr . tcp dport @BTTR_HTTPS counter redirect to $StunMitmEnPort comment ${NFTNAME}_mitm
 	nft insert rule ip STUN BTTR ip daddr 127.0.0.1 $OFFSET_HTTP_GET 0x474554202f616e6e6f756e63653f goto BTTR_HTTP
 }
 

--- a/files/nftables_exit.sh
+++ b/files/nftables_exit.sh
@@ -7,9 +7,8 @@ NFTNAME=Docker_BitComet_$STUN_ORIG_PORT
 CLEANUP() {
 	for HANDLE in $(nft -as list chain ip STUN BTTR_HTTP | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN BTTR_HTTP handle $HANDLE; done
 	for HANDLE in $(nft -as list chain ip STUN BTTR_UDP | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN BTTR_UDP handle $HANDLE; done
-	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"${NFTNAME}_snat\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
-	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"${NFTNAME}_mitm\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
-	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
+	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep $NFTNAME | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
+	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep $NFTNAME | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
 	[ $StunModeLite ] || nft list chain ip STUN NAT_OUTPUT | grep -q BTTR_HTTPS || nft delete set ip STUN BTTR_HTTPS
 	nft list chain ip STUN BTTR_HTTP | grep -qvE '[{}]$|policy accept' || nft delete chain ip STUN BTTR_HTTP
 	nft list chain ip STUN BTTR_UDP | grep -qvE '[{}]$|policy accept' ] || nft delete chain ip STUN BTTR_UDP

--- a/files/nftables_exit.sh
+++ b/files/nftables_exit.sh
@@ -7,7 +7,8 @@ NFTNAME=Docker_BitComet_$STUN_ORIG_PORT
 CLEANUP() {
 	for HANDLE in $(nft -as list chain ip STUN BTTR_HTTP | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN BTTR_HTTP handle $HANDLE; done
 	for HANDLE in $(nft -as list chain ip STUN BTTR_UDP | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN BTTR_UDP handle $HANDLE; done
-	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
+	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"${NFTNAME}_snat\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
+	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"${NFTNAME}_mitm\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
 	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
 	[ $StunModeLite ] || nft list chain ip STUN NAT_OUTPUT | grep -q BTTR_HTTPS || nft delete set ip STUN BTTR_HTTPS
 	nft list chain ip STUN BTTR_HTTP | grep -qvE '[{}]$|policy accept' || nft delete chain ip STUN BTTR_HTTP

--- a/files/nftables_exit.sh
+++ b/files/nftables_exit.sh
@@ -7,20 +7,13 @@ NFTNAME=Docker_BitComet_$STUN_ORIG_PORT
 CLEANUP() {
 	for HANDLE in $(nft -as list chain ip STUN BTTR_HTTP | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN BTTR_HTTP handle $HANDLE; done
 	for HANDLE in $(nft -as list chain ip STUN BTTR_UDP | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN BTTR_UDP handle $HANDLE; done
-	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep $NFTNAME | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
-	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"${NFTNAME}_snat\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
+	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
+	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
+	[ $StunModeLite ] || nft list chain ip STUN NAT_OUTPUT | grep -q BTTR_HTTPS || nft delete set ip STUN BTTR_HTTPS
 	nft list chain ip STUN BTTR_HTTP | grep -qvE '[{}]$|policy accept' || nft delete chain ip STUN BTTR_HTTP
 	nft list chain ip STUN BTTR_UDP | grep -qvE '[{}]$|policy accept' ] || nft delete chain ip STUN BTTR_UDP
 	nft list chain ip STUN NAT_OUTPUT | grep -qvE '[{}]$|policy accept' || nft delete chain ip STUN NAT_OUTPUT
 	nft list chain ip STUN NAT_POSTROUTING | grep -qvE '[{}]$|policy accept' ] || nft delete chain ip STUN NAT_POSTROUTING
-	[ $StunModeLite ] || nft list chain ip STUN HOOK | grep -q BTTR_HTTPS || nft delete set ip STUN BTTR_HTTPS
-	nft list chain ip STUN BTTR_NOFT 2>/dev/null | grep -q \"$NFTNAME\" && {
-		for HANDLE in $(nft -as list chain ip STUN BTTR_NOFT | grep \"$NFTNAME\" | awk '{print$NF}'); do nft delete rule ip STUN BTTR_NOFT handle $HANDLE; done
-		nft list chain ip STUN BTTR_NOFT | grep -qvE '[{}]$' || nft delete chain ip STUN BTTR_NOFT
-		TABLE=$(nft -st list ruleset | sed '/flow add @/q' | grep -oE '^table.*\{' | awk '{print$2,$3}' | tail -1)
-		CHAIN=$(nft -st list ruleset | sed '/flow add @/q' | grep -oE 'chain.*\{' | awk '{print$2}' | tail -1)
-		[ "$TABLE" ] && [ "$CHAIN" ] && for HANDLE in $(nft -as list chain $TABLE $CHAIN | grep \"${NFTNAME}_noft\" | awk '{print$NF}'); do nft delete rule $TABLE $CHAIN handle $HANDLE; done
-	}
 	nft list table ip STUN | grep -q 'chain BTTR_' || nft delete table ip STUN
 	echo 清理 nftables 规则完成 | tee -a /BitComet/DockerLogs.log
 }

--- a/files/start.sh
+++ b/files/start.sh
@@ -492,6 +492,7 @@ else
 		[[ $StunMode =~ tcp ]] && stun.sh tcp &
 		[[ $StunMode =~ udp ]] && stun.sh udp &
 	fi
+	[[ $StunMode =~ nft ]] && [ $StunHost = 1 ] && (pgrep -f nftables_exit.sh >/dev/null || nftables_exit.sh 2>/dev/null &)
 	disown -h $(jobs -p)
 fi
 
@@ -502,7 +503,7 @@ else
 	LOG 已启用 PeerBanHelper，60 秒后启动
 	( sleep 60
 	cd /PeerBanHelper
-	java $JvmArgs -Dpbh.release=docker -Djava.awt.headless=true -Xmx512M -Xms16M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -jar /files/PeerBanHelper/PeerBanHelper.jar | grep 'ERROR' &
+	java $JvmArgs -Dpbh.release=docker -Djava.awt.headless=true -Xmx512M -Xms16M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -jar /files/PeerBanHelper/PeerBanHelper.jar | grep ERROR &
 	LOG PeerBanHelper 已启动，使用以下地址访问 WebUI
 	for IP in $HOSTIP; do LOG http://$IP:$PBH_WEBUI_PORT; done
 	LOG PeerBanHelper 仅输出错误日志，其他内容请从 WebUI 中查看 ) &
@@ -515,7 +516,6 @@ EXIT() {
 	pkill -f stun_keep.sh
 	pkill -f stun_exec.sh
 	pkill -f nftables.sh
-	pkill -f nftables_noft.sh
 	pkill -f socat
 	sleep 1
 	pkill -f nftables_exit.sh

--- a/files/start.sh
+++ b/files/start.sh
@@ -503,10 +503,10 @@ else
 	LOG 已启用 PeerBanHelper，60 秒后启动
 	( sleep 60
 	cd /PeerBanHelper
-	java $JvmArgs -Dpbh.release=docker -Djava.awt.headless=true -Xmx512M -Xms16M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -jar /files/PeerBanHelper/PeerBanHelper.jar | grep ERROR &
+	java $JvmArgs -Dpbh.release=docker -Djava.awt.headless=true -Xmx512M -Xms16M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -jar /files/PeerBanHelper/PeerBanHelper.jar >/dev/null 2>&1 &
 	LOG PeerBanHelper 已启动，使用以下地址访问 WebUI
 	for IP in $HOSTIP; do LOG http://$IP:$PBH_WEBUI_PORT; done
-	LOG PeerBanHelper 仅输出错误日志，其他内容请从 WebUI 中查看 ) &
+	LOG PeerBanHelper 日志已屏蔽，请从 WebUI 中查看 ) &
 fi
 
 # 后期处理

--- a/files/start.sh
+++ b/files/start.sh
@@ -453,8 +453,8 @@ START_NAT() {
 
 # 执行 STUN 及 BitComet
 START_BITCOMET() {
-	[[ $StunMode =~ nft ]] || /files/BitComet/bin/bitcometd &
-	[[ $StunMode =~ nft ]] && runuser -u bitcomet -- /files/BitComet/bin/bitcometd &
+	[[ $StunMode =~ nft ]] || /files/BitComet/bin/bitcometd | grep -v 'IPFilter loaded' &
+	[[ $StunMode =~ nft ]] && runuser -u bitcomet -- /files/BitComet/bin/bitcometd | grep -v 'IPFilter loaded' &
 }
 if [ "$STUN" = 0 ]; then
 	LOG 已禁用 STUN，直接启动 BitComet

--- a/files/start.sh
+++ b/files/start.sh
@@ -512,11 +512,12 @@ fi
 # 后期处理
 EXIT() {
 	LOG 清理容器环境
+	pkill -f socat
 	pkill -f stun.sh
 	pkill -f stun_keep.sh
 	pkill -f stun_exec.sh
+	pkill -f stun_upnp.sh
 	pkill -f nftables.sh
-	pkill -f socat
 	sleep 1
 	pkill -f nftables_exit.sh
 	sleep 2

--- a/files/stun.sh
+++ b/files/stun.sh
@@ -84,11 +84,11 @@ if [[ $StunMode =~ nft ]]; then
 	[ $STUN_IFACE_IF ] && OIFNAME='oifname '$StunInterface''
 	nft add table ip STUN
 	nft add chain ip STUN NAT_OUTPUT { type nat hook output priority dstnat \; }
-	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"${NFTNAME}_snat\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
-	nft insert rule ip STUN NAT_OUTPUT skuid 50080 $OIFNAME $APPRULE meta l4proto $L4PROTO counter ct mark set 0x50080 comment ${NFTNAME}_snat
+	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"$NFTNAME\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
+	nft insert rule ip STUN NAT_OUTPUT skuid 50080 $OIFNAME $APPRULE meta l4proto $L4PROTO counter ct mark set 0x50080 comment $NFTNAME
 	nft add chain ip STUN NAT_POSTROUTING { type nat hook postrouting priority srcnat - 5 \; }
-	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"${NFTNAME}_snat\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
-	nft insert rule ip STUN NAT_POSTROUTING meta l4proto $L4PROTO ct mark 0x50080 counter snat to :$STUN_ORIG_PORT comment ${NFTNAME}_snat
+	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"$NFTNAME\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
+	nft insert rule ip STUN NAT_POSTROUTING meta l4proto $L4PROTO ct mark 0x50080 counter snat to :$STUN_ORIG_PORT comment $NFTNAME
 else
 	export STUN_BIND_PORT=$STUN_ORIG_PORT
 fi

--- a/files/stun.sh
+++ b/files/stun.sh
@@ -84,11 +84,11 @@ if [[ $StunMode =~ nft ]]; then
 	[ $STUN_IFACE_IF ] && OIFNAME='oifname '$StunInterface''
 	nft add table ip STUN
 	nft add chain ip STUN NAT_OUTPUT { type nat hook output priority dstnat \; }
-	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"$NFTNAME\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
-	nft insert rule ip STUN NAT_OUTPUT skuid 50080 $OIFNAME $APPRULE meta l4proto $L4PROTO counter ct mark set 0x50080 comment $NFTNAME
+	for HANDLE in $(nft -as list chain ip STUN NAT_OUTPUT | grep \"${NFTNAME}_snat\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_OUTPUT handle $HANDLE; done
+	nft insert rule ip STUN NAT_OUTPUT skuid 50080 $OIFNAME $APPRULE meta l4proto $L4PROTO counter ct mark set 0x50080 comment ${NFTNAME}_snat
 	nft add chain ip STUN NAT_POSTROUTING { type nat hook postrouting priority srcnat - 5 \; }
-	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"$NFTNAME\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
-	nft insert rule ip STUN NAT_POSTROUTING meta l4proto $L4PROTO ct mark 0x50080 counter snat to :$STUN_ORIG_PORT comment $NFTNAME
+	for HANDLE in $(nft -as list chain ip STUN NAT_POSTROUTING | grep \"${NFTNAME}_snat\" | grep $L4PROTO | awk '{print$NF}'); do nft delete rule ip STUN NAT_POSTROUTING handle $HANDLE; done
+	nft insert rule ip STUN NAT_POSTROUTING meta l4proto $L4PROTO ct mark 0x50080 counter snat to :$STUN_ORIG_PORT comment ${NFTNAME}_snat
 else
 	export STUN_BIND_PORT=$STUN_ORIG_PORT
 fi

--- a/files/stun_upnp.sh
+++ b/files/stun_upnp.sh
@@ -52,5 +52,5 @@ ADD_UPNP
 }
 
 [ $UPNP_FLAG = 0 ] && rm -f StunUpnpConflict_$L4PROTO
-[ $UPNP_FLAG = 1 ] && LOG 更新 UPnP 规则失败，错误信息如下 && LOG "$UPNP_RES" | head -1
-[ $UPNP_FLAG = 2 ] && LOG 更新 UPnP 规则失败，错误信息如下 && LOG "$UPNP_RES" | tail -1
+[ $UPNP_FLAG = 1 ] && LOG 更新 $L4PROTO UPnP 规则失败，错误信息如下 && LOG "$UPNP_RES" | head -1
+[ $UPNP_FLAG = 2 ] && LOG 更新 $L4PROTO UPnP 规则失败，错误信息如下 && LOG "$UPNP_RES" | tail -1


### PR DESCRIPTION
* 初步文档，未完

* 移除不需要的绕过软件加速规则
  软件加速仅对转发链（FORWARD）的流量生效，本方案需要匹配的是输出链（OUTPUT）流量

* 屏蔽 BC 的 IP 过滤器日志

* 屏蔽 PBH 的所有日志
  仅屏蔽标准输出，仍可正常从 WebUI 查看